### PR TITLE
Memory requirements update & Configure claim to match a given volume name

### DIFF
--- a/charts/cassandra/templates/persistentVolumeClaim.yaml
+++ b/charts/cassandra/templates/persistentVolumeClaim.yaml
@@ -8,5 +8,8 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 2Gi
+      storage: 1Gi
+{{- if .Values.pvc.volumeName }}
+  volumeName: {{ .Values.pvc.volumeName }}
+{{- end }}
 {{- end }}

--- a/charts/cassandra/templates/statefulSet.yaml
+++ b/charts/cassandra/templates/statefulSet.yaml
@@ -30,9 +30,9 @@ spec:
         image: "{{ .Chart.Name }}:3.11.2"
         env:
         - name: MAX_HEAP_SIZE
-          value: 128M
+          value: 160M
         - name: HEAP_NEWSIZE
-          value: 48M
+          value: 64M
         ports:
         - containerPort: 7000
           name: intra-node

--- a/charts/cassandra/values.yaml
+++ b/charts/cassandra/values.yaml
@@ -12,4 +12,7 @@ service:
     cqlsh:
       nodePort: 31042
 
+pvc:
+  volumeName:
+
 persistent: true

--- a/charts/mysql/values.yaml
+++ b/charts/mysql/values.yaml
@@ -12,4 +12,7 @@ service:
     mysql:
       nodePort: 31306
 
+pvc:
+  volumeName:
+
 persistent: true


### PR DESCRIPTION
Memory requirements updated to 160M for MAX_HEAP_SIZE and 64M for HEAP_NEWSIZE
Volume name can be set in values.yaml to make sure PVC will match the given volume name